### PR TITLE
Accept the pipeline's own CSV, and refuse builds that lose data

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,18 +94,32 @@ Chart indicators live in `src/data/settings.json`. The default series is IMF cod
 
 ### Regenerating the data
 
-Monthly data is generated from the CSV snapshot:
+Monthly data is generated from the CSV snapshot. **The data ships inside the bundle, so an update is not live until a new build is deployed** — there is no longer a step that changes what visitors see without a release.
 
-1. Replace `src/data/source/combined_imf_database.csv` with the latest `*_combined_imf_database.csv` from the [inflation-database pipeline](https://github.com/africadatahub/adh_inflation_database_v2) (`outputs/ckan/`).
-2. Run the generator:
+1. Get the new CSV. Either works, and both produce identical output:
+
+    - from the [inflation-database pipeline](https://github.com/africadatahub/adh_inflation_database_v2), `outputs/ckan/YYYY-MM-DD_combined_imf_database.csv`; or
+    - while the portal is still up, straight out of CKAN:
+
+        ```
+        curl -o src/data/source/combined_imf_database.csv           https://ckan.africadatahub.org/datastore/dump/56d80035-ba9a-49f8-a670-70be4dd50ce4
+        ```
+
+2. Put it at `src/data/source/combined_imf_database.csv`, replacing what is there.
+3. Run the generator:
 
     ```
     yarn data:build
     ```
 
-3. Commit both the CSV and the regenerated `src/data/inflation.json`, then rebuild and redeploy — the data ships inside the bundle, so a data change needs a new build.
+4. Read what it prints. It reports the country/indicator/month counts, the date range, and a comparison against the build it just replaced — new months, added countries, and any loss of coverage. **It exits non-zero if the new file has fewer values than the old one**, because a partial export is the likely failure (the `reshaped` resource on CKAN has silently been truncated to five countries before). Do not commit a build that warns.
+5. Commit both the CSV and the regenerated `src/data/inflation.json`.
+6. Build and deploy as under [Hosting & deployment](#hosting--deployment).
 
-The generator prints the country/indicator/month counts and the date range; check them against the CSV before committing.
+Two cases need a second file changed by hand:
+
+- **A country appears in the data that is not in the app.** The generator picks it up automatically, but the picker and the URL slugs come from `src/data/countries.json`. Add it there or it stays unreachable.
+- **A new indicator appears.** It lands in `inflation.json`, but the dropdown is driven by the `indicators` array in `src/data/settings.json`. Add the code and its display name there. The two lists should stay in step in both directions — a code listed in `settings.json` but missing from the data charts as an empty line.
 
 Annual rates are static. To refresh them:
 

--- a/scripts/build-inflation-data.js
+++ b/scripts/build-inflation-data.js
@@ -22,10 +22,24 @@ const path = require('path');
 const SOURCE = path.join(__dirname, '..', 'src', 'data', 'source', 'combined_imf_database.csv');
 const TARGET = path.join(__dirname, '..', 'src', 'data', 'inflation.json');
 
-// CKAN prefixes any column starting with a digit with `unsafe_` on ingest, and
-// swaps the dashes for underscores. Accept both that and a plain date heading,
-// so the script also works against a CSV taken straight from the pipeline.
+/*
+ * Two spellings of the same file are in circulation, and both are accepted:
+ *
+ *   Straight from the pipeline   `Indicator.Code`, `Geography`, `2025-07-31`
+ *   Dumped back out of CKAN      `indicator_code`, `Geography`, `unsafe_2025_07_31`
+ *
+ * CKAN lowercases headings, replaces dots with underscores, and prefixes any
+ * column starting with a digit with `unsafe_`, so a round trip through the
+ * portal renames most of the file.
+ */
 const DATE_COLUMN = /^(?:unsafe_)?(\d{4})[-_](\d{2})[-_](\d{2})$/;
+
+const normalise = (heading) => heading.trim().toLowerCase().replace(/[.\-\s]/g, '_');
+
+const findColumn = (header, ...names) => {
+    let wanted = names.map(normalise);
+    return header.findIndex(heading => wanted.includes(normalise(heading)));
+};
 
 // Minimal RFC 4180 reader — the indicator names contain commas ("Consumer
 // Price Index, All items"), so splitting on commas alone is not enough.
@@ -87,11 +101,14 @@ if (rows.length < 2) {
 }
 
 const header = rows[0];
-const isoColumn = header.indexOf('Geography');
-const indicatorColumn = header.indexOf('indicator_code');
+const isoColumn = findColumn(header, 'Geography', 'iso_code');
+const indicatorColumn = findColumn(header, 'indicator_code', 'Indicator.Code');
 
 if (isoColumn === -1 || indicatorColumn === -1) {
-    throw new Error('CSV is missing a Geography or indicator_code column');
+    throw new Error(
+        'CSV needs a country column (Geography / iso_code) and an indicator column ' +
+        '(Indicator.Code / indicator_code). Found: ' + header.slice(0, 8).join(', ')
+    );
 }
 
 const dateColumns = [];
@@ -140,16 +157,54 @@ const output = {
     countries
 };
 
+const countValues = (grid) => grid.reduce((n, series) => n + series.filter(v => v !== null).length, 0);
+
+// Compare against the file being replaced before overwriting it. A partial
+// export is the failure mode worth catching here: the `reshaped` resource on
+// CKAN has silently been truncated to five countries before now, and a short
+// CSV would otherwise regenerate cleanly and quietly drop data from the site.
+let previous = null;
+if (fs.existsSync(TARGET)) {
+    try {
+        previous = JSON.parse(fs.readFileSync(TARGET, 'utf8'));
+    } catch (error) {
+        console.warn(`  (could not read the existing ${path.basename(TARGET)} to compare against)`);
+    }
+}
+
 fs.writeFileSync(TARGET, JSON.stringify(output));
 
-const values = Object.values(countries).length * indicators.length * output.dates.length;
-const populated = Object.values(countries)
-    .reduce((total, grid) => total + grid.reduce((n, s) => n + s.filter(v => v !== null).length, 0), 0);
+const total = Object.keys(countries).length * indicators.length * output.dates.length;
+const populated = Object.values(countries).reduce((n, grid) => n + countValues(grid), 0);
 
 console.log(`Wrote ${path.relative(process.cwd(), TARGET)}`);
 console.log(
     `  ${Object.keys(countries).length} countries x ${indicators.length} indicators x ${output.dates.length} months` +
     ` (${output.dates[0]} to ${output.dates[output.dates.length - 1]})`
 );
-console.log(`  ${populated.toLocaleString()} of ${values.toLocaleString()} values present`);
+console.log(`  ${populated.toLocaleString()} of ${total.toLocaleString()} values present`);
 console.log(`  ${(fs.statSync(TARGET).size / 1024).toFixed(0)} KB on disk`);
+
+if (previous && previous.countries) {
+    let added = Object.keys(countries).filter(iso => !previous.countries[iso]);
+    let dropped = Object.keys(previous.countries).filter(iso => !countries[iso]);
+    let lost = Object.keys(countries)
+        .filter(iso => previous.countries[iso])
+        .map(iso => ({ iso, delta: countValues(countries[iso]) - countValues(previous.countries[iso]) }))
+        .filter(c => c.delta < 0);
+
+    let previousPopulated = Object.values(previous.countries).reduce((n, grid) => n + countValues(grid), 0);
+    let newMonths = output.dates.filter(d => !previous.dates.includes(d));
+
+    console.log('\nAgainst the previous build:');
+    console.log(`  ${(populated - previousPopulated >= 0 ? '+' : '') + (populated - previousPopulated).toLocaleString()} values` +
+        (newMonths.length ? `, ${newMonths.length} new month(s) to ${newMonths[newMonths.length - 1]}` : ', no new months'));
+    if (added.length) console.log(`  added: ${added.join(', ')}`);
+
+    if (dropped.length || lost.length) {
+        console.error('\n  ⚠ THIS BUILD LOSES DATA — check the CSV is a complete export before committing');
+        if (dropped.length) console.error(`    countries gone: ${dropped.join(', ')}`);
+        if (lost.length) console.error(`    fewer values: ${lost.map(c => `${c.iso} (${c.delta})`).join(', ')}`);
+        process.exitCode = 1;
+    }
+}


### PR DESCRIPTION
Accept the pipeline's own CSV, and refuse builds that lose data

The documented refresh path did not work. The generator was written against a CKAN dump, where ingest has lowercased Indicator.Code to indicator_code, so feeding it the pipeline's own outputs/ckan CSV failed on the first column lookup -- which is what a real data update would have started from.

Headings are now normalised, so both spellings work. Verified against the pipeline CSV recovered from adh_inflation_database_v2: both inputs produce byte-identical output, confirming the CKAN copy and the pipeline file are the same data.

Also compare each build against the one it replaces and exit non-zero if coverage drops. A partial export is the realistic failure here -- CKAN's reshaped_imf_database resource is silently truncated to five countries -- and a short CSV would otherwise regenerate cleanly and quietly drop countries from the site. A normal update reports new months and added countries and exits 0.

Documents the full refresh sequence in the README, including that a data change is not live until a new build is deployed, and the two cases that need countries.json or settings.json edited alongside the data.